### PR TITLE
Build package prior to polluting git tree

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -66,6 +66,9 @@ jobs:
         tags: true
         unprotect_reviews: true
 
+    - name: Build source distribution
+      run: flit build
+
     - name: Get tagged versions
       run: echo "PREVIOUS_VERSION=$(git tag -l --sort -version:refname | sed -n 2p)" >> $GITHUB_ENV
 
@@ -84,9 +87,6 @@ jobs:
         gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} -X PATCH -F body='@release_body.md'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Build source distribution
-      run: flit build
 
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@v1.5.0


### PR DESCRIPTION
Fixes #23 

By moving up the build source distribution step to before creating more changelog files to update the release documentation, the repository folder should be `git` clean.