### PR TITLE
New CD workflow to update dependencies in pyproject.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,5 @@
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: monday
-    time: "05:18"
-  # Should be bigger than or equal to the total number of dependencies (currently 11)
-  open-pull-requests-limit: 20
-  target-branch: ci/dependency-updates
-  labels:
-    - CI/CD
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.github/utils/pyproject_toml_update_pr_body.txt
+++ b/.github/utils/pyproject_toml_update_pr_body.txt
@@ -1,0 +1,3 @@
+### Update dependencies (`pyproject.toml`)
+
+Automatically created PR from the [`cd_dependencies.yml` workflow](https://github.com/SINTEF/oteapi-optimade/blob/main/.github/workflows/cd_dependencies.yml).

--- a/.github/workflows/cd_dependencies.yml
+++ b/.github/workflows/cd_dependencies.yml
@@ -1,0 +1,76 @@
+name: CD - Check dependencies
+
+on:
+  schedule:
+    # At 7:30 every Monday (5:30 UTC)
+    - cron: "30 5 * * 1"
+  workflow_dispatch:
+
+jobs:
+  update-dependencies:
+    name: Update dependencies
+    if: github.repository_owner == 'SINTEF'
+    runs-on: ubuntu-latest
+    env:
+      DEPENDABOT_BRANCH: ci/dependency-updates
+      GIT_USER_NAME: "TEAM 4.0[bot]"
+      GIT_USER_EMAIL: "Team4.0@SINTEF.no"
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ env.DEPENDABOT_BRANCH }}
+        fetch-depth: 0
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.9"
+
+    - name: Set up git user info
+      run: |
+        git config --global user.name "${{ env.GIT_USER_NAME }}"
+        git config --global user.email "${{ env.GIT_USER_EMAIL }}"
+
+    - name: Install necessary dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools wheel flit
+        pip install .[dev]
+
+    - name: Run invoke task
+      run: |
+        invoke update-deps
+
+        if [ -n "$(git status --porcelain pyproject.toml)" ]; then
+          echo "UPDATE_DEPS=true" >> $GITHUB_ENV
+          git add pyproject.toml
+          git commit -m "Update dependencies"
+        else
+          echo "UPDATE_DEPS=false" >> $GITHUB_ENV
+
+    - name: Fetch PR body
+      if: env.UPDATE_DEPS == 'true'
+      id: pr_body
+      uses: chuhlomin/render-template@v1.5
+      with:
+        template: .github/utils/pyproject_toml_update_pr_body.txt
+
+    - name: Create PR
+      if: env.UPDATE_DEPS == 'true'
+      id: cpr
+      uses: peter-evans/create-pull-request@v4
+      with:
+        token: ${{ secrets.RELEASE_PAT }}
+        commit-message: Update dependencies
+        committer: "${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>"
+        author: "${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>"
+        branch: ci/update-pyproject
+        delete-branch: true
+        title: "[Auto-generated] Update dependencies (`pyproject.toml`)"
+        body: ${{ steps.pr_body.outputs.result }}
+        labels: CI/CD
+
+    - name: Information
+      run: 'echo "${{ steps.cpr.outputs.pull-request-operation }} PR #${{ steps.cpr.outputs.pull-request-number }}: ${{ steps.cpr.outputs.pull-request-url }}"'

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -11,7 +11,6 @@ env:
   GIT_USER_EMAIL: "Team4.0@SINTEF.no"
 
 jobs:
-
   update-and-publish:
     name: Update CHANGELOG and version and publish to PyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -6,6 +6,7 @@ on:
     # Dependabot runs once a week (every Monday) (pip)
     # and every day (GH Actions) between 7:00 and 7:30 (5:00-5:30 UTC)
     - cron: "30 6 * * 3"
+  workflow_dispatch:
 
 jobs:
   create-collected-pr:
@@ -77,7 +78,7 @@ jobs:
       uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.RELEASE_PAT }}
-        commit-message: New @dependabot-fueled updates
+        commit-message: New @dependabot and CD workflow fueled updates
         committer: "${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>"
         author: "${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>"
         branch: ci/update-dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
     "pytest-cov ~=3.0",
     "pyyaml ~=6.0",
     "requests-mock ~=1.9",
+    "tomlkit ~=0.11.0",
 ]
 
 [project.urls]

--- a/tasks.py
+++ b/tasks.py
@@ -192,3 +192,121 @@ def create_docs_index(_):
         content = content.replace(old, new)
 
     docs_index.write_text(content, encoding="utf8")
+
+
+@task(
+    help={
+        "fail-fast": (
+            "Fail immediately if an error occurs. Otherwise, print and ignore all "
+            "non-critical errors."
+        ),
+    }
+)
+def update_deps(context, fail_fast=False):  # pylint: disable=too-many-branches
+    """Update dependencies in `pyproject.toml`."""
+    import tomlkit
+
+    if TYPE_CHECKING:  # pragma: no cover
+        context: "Context" = context
+
+    pyproject_path = TOP_DIR / "pyproject.toml"
+    pyproject = tomlkit.loads(pyproject_path.read_bytes())
+
+    py_version = re.match(
+        r"^.*(?P<version>3\.[0-9]+)$",
+        pyproject.get("project", {}).get("requires-python", ""),
+    ).group("version")
+
+    already_handled_packages = []
+    updated_packages = {}
+    dependencies = pyproject.get("project", {}).get("dependencies", [])
+    for optional_deps in (
+        pyproject.get("project", {}).get("optional-dependencies", {}).values()
+    ):
+        dependencies.extend(optional_deps)
+    for line in dependencies:
+        match = re.match(
+            r"^(?P<full_dependency>(?P<package>[a-zA-Z0-9-_]+)\S*) "
+            r"(?P<operator>>|<|<=|>=|==|!=|~=)"
+            r"(?P<version>[0-9]+(?:\.[0-9]+){0,2})$",
+            line,
+        )
+        if match is None:
+            msg = f"Could not parse package, operator, and version for line:\n  {line}"
+            if fail_fast:
+                sys.exit(msg)
+            print(msg)
+        full_dependency_name = match.group("full_dependency")
+        package = match.group("package")
+        operator = match.group("operator")
+        version = match.group("version")
+
+        # Skip package if already handled
+        if package in already_handled_packages:
+            continue
+
+        out: "Result" = context.run(
+            f"pip index versions --python-version {py_version} {package}",
+            hide=True,
+        )
+        package_latest_version_line = out.stdout.split(sep="\n", maxsplit=1)[0]
+        match = re.match(
+            r"(?P<package>[a-zA-Z0-9-_]+) \((?P<version>[0-9]+(?:\.[0-9]+){0,2})\)",
+            package_latest_version_line,
+        )
+        if match is None:
+            msg = (
+                "Could not parse package and version from 'pip index versions' output "
+                f"for line:\n  {package_latest_version_line}"
+            )
+            if fail_fast:
+                sys.exit(msg)
+            print(msg)
+
+        # Sanity check
+        if package != match.group("package"):
+            msg = (
+                f"Package name parsed from pyproject.toml ({package!r}) does not match"
+                " the name returned from 'pip index versions': "
+                f"{match.group('package')!r}"
+            )
+            if fail_fast:
+                sys.exit(msg)
+            print(msg)
+
+        latest_version = match.group("version").split(".")
+        for index, version_part in enumerate(version.split(".")):
+            if version_part != latest_version[index]:
+                break
+        else:
+            already_handled_packages.append(package)
+            continue
+
+        # Update pyproject.toml
+        updated_version = ".".join(latest_version[: len(version.split("."))])
+        escaped_full_dependency_name = full_dependency_name.replace(
+            "[", "\["  # pylint: disable=anomalous-backslash-in-string
+        ).replace(
+            "]", "\]"  # pylint: disable=anomalous-backslash-in-string
+        )
+        update_file(
+            pyproject_path,
+            (
+                rf'"{escaped_full_dependency_name} {operator}.*"',
+                f'"{full_dependency_name} {operator}{updated_version}"',
+            ),
+        )
+        already_handled_packages.append(package)
+        updated_packages[full_dependency_name] = f"{operator}{updated_version}"
+
+    if updated_packages:
+        print(
+            "Successfully updated the following dependencies:\n"
+            + "\n".join(
+                f"  {package} ({version})"
+                for package, version in updated_packages.items()
+            )
+            + "\n"
+        )
+    else:
+        print("No dependency updates available.")


### PR DESCRIPTION
Closes #46 

A new invoke task will update the dependencies read from `pyproject.toml` according to what is returned from `pip index versions` for Python 3.9, or more specifically for the lowest versioned Python that is supported.