### PR TITLE
Use new repo name for callable workflows repo

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish-package-and-docs:
     name: Call external workflow
-    uses: CasperWA/ci-cd/.github/workflows/cd_release.yml@main
+    uses: CasperWA/ci-cd/.github/workflows/cd_release.yml@v1
     if: github.repository == 'SINTEF/oteapi-optimade' && startsWith(github.ref, 'refs/tags/v')
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish-package-and-docs:
     name: Call external workflow
-    uses: CasperWA/gh-actions/.github/workflows/cd_release.yml@main
+    uses: CasperWA/ci-cd/.github/workflows/cd_release.yml@main
     if: github.repository == 'SINTEF/oteapi-optimade' && startsWith(github.ref, 'refs/tags/v')
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_automerge_dependency_prs.yml
+++ b/.github/workflows/ci_automerge_dependency_prs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependencies-branch:
     name: Call external workflow
-    uses: CasperWA/gh-actions/.github/workflows/ci_automerge_prs.yml@main
+    uses: CasperWA/ci-cd/.github/workflows/ci_automerge_prs.yml@main
     if: github.repository_owner == 'SINTEF' && ( ( startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]' ) || ( github.event.pull_request.head.ref == 'ci/update-pyproject' && github.actor == 'TEAM4-0' ) )
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_automerge_dependency_prs.yml
+++ b/.github/workflows/ci_automerge_dependency_prs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependencies-branch:
     name: Call external workflow
-    uses: CasperWA/ci-cd/.github/workflows/ci_automerge_prs.yml@main
+    uses: CasperWA/ci-cd/.github/workflows/ci_automerge_prs.yml@v1
     if: github.repository_owner == 'SINTEF' && ( ( startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]' ) || ( github.event.pull_request.head.ref == 'ci/update-pyproject' && github.actor == 'TEAM4-0' ) )
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-deps-branch-and-docs:
     name: Call external workflow
-    uses: CasperWA/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@main
+    uses: CasperWA/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v1
     if: github.repository_owner == 'SINTEF'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-deps-branch-and-docs:
     name: Call external workflow
-    uses: CasperWA/gh-actions/.github/workflows/ci_cd_updated_default_branch.yml@main
+    uses: CasperWA/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@main
     if: github.repository_owner == 'SINTEF'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check-dependencies:
     name: Call external workflow
-    uses: CasperWA/gh-actions/.github/workflows/ci_check_pyproject_dependencies.yml@main
+    uses: CasperWA/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@main
     if: github.repository_owner == 'SINTEF'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check-dependencies:
     name: Call external workflow
-    uses: CasperWA/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@main
+    uses: CasperWA/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v1
     if: github.repository_owner == 'SINTEF'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -133,10 +133,10 @@ jobs:
         fetch-depth: 2
         path: main
 
-    - name: Checkout CasperWA/gh-actions
+    - name: Checkout CasperWA/ci-cd
       uses: actions/checkout@v3
       with:
-        repository: CasperWA/gh-actions
+        repository: CasperWA/ci-cd
         ref: main
         path: gh-actions
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -138,7 +138,7 @@ jobs:
       with:
         repository: CasperWA/ci-cd
         ref: main
-        path: gh-actions
+        path: ci-cd
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
@@ -150,7 +150,7 @@ jobs:
         python -m pip install -U pip
         pip install -U setuptools wheel flit
         pip install ./main[doc]
-        pip install -r ./gh-actions/requirements.txt
+        pip install -r ./ci-cd/requirements.txt
 
     - name: Update API Reference and landing page
       run: |
@@ -165,7 +165,7 @@ jobs:
         invoke create-docs-index \
           --repo-folder=main \
           --replacements="(LICENSE),(LICENSE.md)"
-      working-directory: ./gh-actions
+      working-directory: ./ci-cd
 
     - name: Build documentation
       run: mkdocs build --strict

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -137,7 +137,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: CasperWA/ci-cd
-        ref: main
+        ref: v1
         path: ci-cd
 
     - name: Set up Python 3.9

--- a/.github/workflows/ci_update_dependencies.yml
+++ b/.github/workflows/ci_update_dependencies.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   create-collected-pr:
     name: Call external workflow
-    uses: CasperWA/ci-cd/.github/workflows/ci_update_dependencies.yml@main
+    uses: CasperWA/ci-cd/.github/workflows/ci_update_dependencies.yml@v1
     if: github.repository_owner == 'SINTEF'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_update_dependencies.yml
+++ b/.github/workflows/ci_update_dependencies.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   create-collected-pr:
     name: Call external workflow
-    uses: CasperWA/gh-actions/.github/workflows/ci_update_dependencies.yml@main
+    uses: CasperWA/ci-cd/.github/workflows/ci_update_dependencies.yml@main
     if: github.repository_owner == 'SINTEF'
     with:
       git_username: "TEAM 4.0[bot]"


### PR DESCRIPTION
Closes #66 

This should be merged to also use `v1` instead of `main` directly.