### PR TITLE
Use CasperWA/ci-cd pre-commit hooks

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish-package-and-docs:
     name: Call external workflow
-    uses: CasperWA/ci-cd/.github/workflows/cd_release.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v1
     if: github.repository == 'SINTEF/oteapi-optimade' && startsWith(github.ref, 'refs/tags/v')
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_automerge_dependency_prs.yml
+++ b/.github/workflows/ci_automerge_dependency_prs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependencies-branch:
     name: Call external workflow
-    uses: CasperWA/ci-cd/.github/workflows/ci_automerge_prs.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v1
     if: github.repository_owner == 'SINTEF' && ( ( startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]' ) || ( github.event.pull_request.head.ref == 'ci/update-pyproject' && github.actor == 'TEAM4-0' ) )
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-deps-branch-and-docs:
     name: Call external workflow
-    uses: CasperWA/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v1
     if: github.repository_owner == 'SINTEF'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check-dependencies:
     name: Call external workflow
-    uses: CasperWA/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v1
     if: github.repository_owner == 'SINTEF'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -131,14 +131,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 2
-        path: main
-
-    - name: Checkout CasperWA/ci-cd
-      uses: actions/checkout@v3
-      with:
-        repository: CasperWA/ci-cd
-        ref: v1
-        path: ci-cd
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
@@ -149,27 +141,15 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install -U setuptools wheel flit
-        pip install ./main[doc]
-        pip install -r ./ci-cd/requirements.txt
+        pip install .[doc,pre-commit]
 
     - name: Update API Reference and landing page
       run: |
-        invoke create-api-reference-docs \
-          --pre-clean \
-          --repo-folder=main \
-          --package-dir="oteapi_optimade" \
-          --unwanted-dirs="__pycache__" \
-          --unwanted-files="__init__.py" \
-          --full-docs-dirs="models"
-
-        invoke create-docs-index \
-          --repo-folder=main \
-          --replacements="(LICENSE),(LICENSE.md)"
-      working-directory: ./ci-cd
+        pre-commit run --all-files docs-api-reference
+        pre-commit run --all-files docs-landing-page
 
     - name: Build documentation
       run: mkdocs build --strict
-      working-directory: ./main
 
   pytest-real-backend:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -145,8 +145,8 @@ jobs:
 
     - name: Update API Reference and landing page
       run: |
-        pre-commit run --all-files docs-api-reference
-        pre-commit run --all-files docs-landing-page
+        pre-commit run --all-files --verbose docs-api-reference
+        pre-commit run --all-files --verbose docs-landing-page
 
     - name: Build documentation
       run: mkdocs build --strict

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -8,59 +8,24 @@ on:
       - 'push-action/**'  # Allow pushing to protected branches (using CasperWA/push-protected)
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout oteapi-optimade
-      uses: actions/checkout@v3
-
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.9"
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U setuptools wheel flit
-        pip install .[pre-commit]
-
-    - name: Test with pre-commit
-      run: SKIP=pylint,pylint-tests pre-commit run --all-files
-
-  pylint-safety:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout oteapi-optimade
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 2
-
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-
-    - name: Install dependencies
-      run: |
-        python -m pip install -U pip
-        pip install -U setuptools wheel flit
-        pip install -e .[dev]
-        pip install safety
-
-    - name: Run pylint
-      run: pylint --rcfile=pyproject.toml --ignore-paths=tests/ --extension-pkg-whitelist='pydantic' oteapi_optimade
-
-    - name: Run pylint - tests
-      run: pylint --rcfile=pyproject.toml --extension-pkg-whitelist='pydantic' --disable=import-outside-toplevel,redefined-outer-name tests
-
-    # Ignore ID 44715 for now.
-    # See this NumPy issue for more information: https://github.com/numpy/numpy/issues/19038
-    # NumPy is a sub-dependency of `oteapi-core`
-    - name: Run safety
-      run: pip freeze | safety check --stdin --ignore 44715
+  basic-tests:
+    name: Call external workflow
+    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v1
+    with:
+      python_version: "3.9"
+      install_extras: "[dev,pre-commit,doc]"
+      skip_pre-commit_hooks: pylint,pylint-tests
+      pylint_runs: |
+        --rcfile=pyproject.toml --ignore-paths=tests/ --extension-pkg-whitelist='pydantic' oteapi_optimade
+        --rcfile=pyproject.toml --extension-pkg-whitelist='pydantic' --disable=import-outside-toplevel,redefined-outer-name tests
+      # Ignore ID 44715 for now.
+      # See this NumPy issue for more information: https://github.com/numpy/numpy/issues/19038
+      # NumPy is a sub-dependency of `oteapi-core`
+      safety_options: "--ignore=44715"
+      build_libs: flit
+      build_cmd: flit build
+      package_dir: oteapi_optimade
+      full_docs_dirs: "models"
 
   pytest:
     name: pytest (${{ matrix.os[1] }}-py${{ matrix.python-version }})
@@ -100,56 +65,6 @@ jobs:
       with:
         files: coverage.xml
         flags: ${{ matrix.os[1] }}
-
-  build-package:
-    name: Build distribution package
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout oteapi-optimade
-      uses: actions/checkout@v3
-
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.9"
-
-    - name: Install dependencies
-      run: |
-        python -m pip install -U pip
-        pip install -U setuptools wheel flit
-
-    - name: Check building distribution
-      run: flit build
-
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout oteapi-optimade
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 2
-
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.9"
-
-    - name: Install dependencies
-      run: |
-        python -m pip install -U pip
-        pip install -U setuptools wheel flit
-        pip install .[doc,pre-commit]
-
-    - name: Update API Reference and landing page
-      run: |
-        pre-commit run --all-files --verbose docs-api-reference
-        pre-commit run --all-files --verbose docs-landing-page
-
-    - name: Build documentation
-      run: mkdocs build --strict
 
   pytest-real-backend:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_update_dependencies.yml
+++ b/.github/workflows/ci_update_dependencies.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   create-collected-pr:
     name: Call external workflow
-    uses: CasperWA/ci-cd/.github/workflows/ci_update_dependencies.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v1
     if: github.repository_owner == 'SINTEF'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,17 +42,14 @@ repos:
         - "types-requests"
         - "pydantic"
 
-  - repo: https://github.com/CasperWA/ci-cd
-    rev: e177317eeeef00f5c968f2cc986ad8f45c911866  # frozen: v1
+  - repo: https://github.com/SINTEF/ci-cd
+    rev: e46548040dd6afa0b8204151d7ed988d96252a4b  # frozen: v1
     hooks:
     - id: docs-api-reference
       args:
       - "--package-dir=oteapi_optimade"
-      - "--full-docs-dirs=models"
+      - "--full-docs-folder=models"
     - id: docs-landing-page
-      args:
-      - "--replacements"
-      - "(LICENSE),(LICENSE.md)"
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,18 @@ repos:
         - "types-requests"
         - "pydantic"
 
+  - repo: https://github.com/CasperWA/ci-cd
+    rev: e177317eeeef00f5c968f2cc986ad8f45c911866  # frozen: v1
+    hooks:
+    - id: docs-api-reference
+      args:
+      - "--package-dir=oteapi_optimade"
+      - "--full-docs-dirs=models"
+    - id: docs-landing-page
+      args:
+      - "--replacements"
+      - "(LICENSE),(LICENSE.md)"
+
   - repo: local
     hooks:
     - id: pylint

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ edit_uri: ""
 
 extra:
   social:
-    - icon: fontawesome/brands/github
+    - icon: fontawesome/brands/github-square
       link: https://github.com/SINTEF
       name: "SINTEF on GitHub"
     - icon: fontawesome/brands/github


### PR DESCRIPTION
Closes #68 
Closes #71 
Fixes #72 

Use the pre-commit hooks at [CasperWA/ci-cd](https://github.com/CasperWA/ci-cd).
See the documentation on them [here](https://CasperWA.github.io/ci-cd/latest/hooks/index).