### PR TITLE
Update to SINTEF/ci-cd v2

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -7,21 +7,29 @@ on:
 
 jobs:
   publish-package-and-docs:
-    name: Call external workflow
+    name: External
     uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.2.1
     if: github.repository == 'SINTEF/oteapi-optimade' && startsWith(github.ref, 'refs/tags/v')
     with:
+      # General
       git_username: "TEAM 4.0[bot]"
       git_email: "Team4.0@SINTEF.no"
+
+      # Python package
+      python_package: true
       package_dirs: oteapi_optimade
       release_branch: main
       install_extras: "[dev]"
       python_version_build: "3.9"
       build_cmd: "pip install -U flit && flit build"
+      publish_on_pypi: true
+
+      # Documentation
       update_docs: true
       python_version_docs: "3.9"
       doc_extras: "[doc]"
       changelog_exclude_labels: "skip_changelog,duplicate,question,invalid,wontfix"
+
     secrets:
       PyPI_token: ${{ secrets.PYPI_TOKEN }}
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish-package-and-docs:
     name: Call external workflow
-    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.2.1
     if: github.repository == 'SINTEF/oteapi-optimade' && startsWith(github.ref, 'refs/tags/v')
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_automerge_dependency_prs.yml
+++ b/.github/workflows/ci_automerge_dependency_prs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependencies-branch:
     name: Call external workflow
-    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v2.2.1
     if: github.repository_owner == 'SINTEF' && ( ( startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]' ) || ( github.event.pull_request.head.ref == 'ci/update-pyproject' && github.actor == 'TEAM4-0' ) )
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_automerge_dependency_prs.yml
+++ b/.github/workflows/ci_automerge_dependency_prs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update-dependencies-branch:
-    name: Call external workflow
+    name: External
     uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v2.2.1
     if: github.repository_owner == 'SINTEF' && ( ( startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]' ) || ( github.event.pull_request.head.ref == 'ci/update-pyproject' && github.actor == 'TEAM4-0' ) )
     secrets:

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -6,20 +6,27 @@ on:
 
 jobs:
   update-deps-branch-and-docs:
-    name: Call external workflow
+    name: External
     uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v2.2.1
     if: github.repository_owner == 'SINTEF'
     with:
+      # General
       git_username: "TEAM 4.0[bot]"
       git_email: "Team4.0@SINTEF.no"
+
+      # Update dependency branch
       permanent_dependencies_branch: "ci/dependency-updates"
       default_repo_branch: main
-      package_dirs: oteapi_optimade
+
+      # Update documentation
       update_docs: true
       update_python_api_ref: true
       update_docs_landing_page: true
+      package_dirs: oteapi_optimade
       python_version: "3.9"
       doc_extras: "[doc]"
       full_docs_dirs: models
+      changelog_exclude_labels: "skip_changelog,duplicate,question,invalid,wontfix"
+
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-deps-branch-and-docs:
     name: Call external workflow
-    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v2.2.1
     if: github.repository_owner == 'SINTEF'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check-dependencies:
     name: Call external workflow
-    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.2.1
     if: github.repository_owner == 'SINTEF'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-dependencies:
-    name: Call external workflow
+    name: External
     uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.2.1
     if: github.repository_owner == 'SINTEF'
     with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   basic-tests:
-    name: Call external workflow
+    name: External
     uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.2.1
     with:
       # General setup

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   basic-tests:
     name: Call external workflow
-    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.2.1
     with:
       # General setup
       install_extras: "[dev]"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -24,10 +24,6 @@ jobs:
       pylint_runs: |
         --rcfile=pyproject.toml --ignore-paths=tests/ --extension-pkg-whitelist='pydantic' oteapi_optimade
         --rcfile=pyproject.toml --extension-pkg-whitelist='pydantic' --disable=import-outside-toplevel,redefined-outer-name --recursive=yes tests
-      # Ignore ID 44715 for now.
-      # See this NumPy issue for more information: https://github.com/numpy/numpy/issues/19038
-      # NumPy is a sub-dependency of `oteapi-core`
-      safety_options: "--ignore=44715"
 
       # Build dist
       python_version_package: "3.9"

--- a/.github/workflows/ci_update_dependencies.yml
+++ b/.github/workflows/ci_update_dependencies.yml
@@ -8,16 +8,19 @@ on:
 
 jobs:
   create-collected-pr:
-    name: Call external workflow
+    name: External
     uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v2.2.1
     if: github.repository_owner == 'SINTEF'
     with:
+      # General
       git_username: "TEAM 4.0[bot]"
       git_email: "Team4.0@SINTEF.no"
       permanent_dependencies_branch: "ci/dependency-updates"
       default_repo_branch: main
       pr_labels: "CI/CD,skip_changelog"
       extra_to_dos: "- [ ] Make sure that the PR is **squash** merged, with a sensible commit message."
+
+      # Update pre-commit hooks
       update_pre-commit: true
       python_version: "3.9"
       install_extras: "[pre-commit]"

--- a/.github/workflows/ci_update_dependencies.yml
+++ b/.github/workflows/ci_update_dependencies.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   create-collected-pr:
     name: Call external workflow
-    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v2.2.1
     if: github.repository_owner == 'SINTEF'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         - "pydantic"
 
   - repo: https://github.com/SINTEF/ci-cd
-    rev: v2.1.0
+    rev: v2.2.1
     hooks:
     - id: docs-api-reference
       args:


### PR DESCRIPTION
Closes #104 

Use the latest version of [SINTEF/ci-cd](https://sintef.github.io/ci-cd), which is currently v2.2.1.

Update how the inputs to the callable workflows are listed and also remove the `safety` ignore statement concerning NumPy, as this issue has been fixed.