### PR TITLE
Move from pylint (& isort) to ruff

### DIFF
--- a/.github/utils/end2end_test.py
+++ b/.github/utils/end2end_test.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 """End-to-end testing in CI for OTEAPI OPTIMADE (using OTELib)."""
-# pylint: disable=import-outside-toplevel
 import importlib
 import json
 import os
@@ -62,7 +61,7 @@ def main(oteapi_url: str) -> None:
         }
     }
 
-    source = client.create_dataresource(  # pylint: disable=no-member
+    source = client.create_dataresource(
         accessService="OPTIMADE",
         accessUrl=f"http://localhost:{os.getenv('OPTIMADE_PORT', '5000')}/",
         configuration=config,
@@ -85,7 +84,7 @@ def main(oteapi_url: str) -> None:
         assert parsed_resource.id in ["mpf_1", "mpf_110"]
 
     # Use a filter strategy
-    query = client.create_filter(  # pylint: disable=no-member
+    query = client.create_filter(
         filterType="OPTIMADE",
         query='NOT( elements HAS "Ag" AND nelements>1 )',
         limit=4,
@@ -143,5 +142,5 @@ if __name__ == "__main__":
 
     try:
         main(oteapi_url=OTEAPI_SERVICE_URL)
-    except Exception as exc:  # pylint: disable=broad-except
+    except Exception as exc:
         sys.exit(str(exc))

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -17,13 +17,11 @@ jobs:
 
       # pre-commit
       python_version_pre-commit: "3.9"
-      skip_pre-commit_hooks: pylint,pylint-tests
 
       # pylint & safety
       python_version_pylint_safety: "3.9"
-      pylint_runs: |
-        --rcfile=pyproject.toml --ignore-paths=tests/ --extension-pkg-whitelist='pydantic' oteapi_optimade
-        --rcfile=pyproject.toml --extension-pkg-whitelist='pydantic' --disable=import-outside-toplevel,redefined-outer-name --recursive=yes tests
+      run_pylint: false
+      run_safety: true
 
       # Build dist
       python_version_package: "3.9"
@@ -34,6 +32,14 @@ jobs:
       python_version_docs: "3.9"
       package_dirs: oteapi_optimade
       full_docs_dirs: "models"
+
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: chartboost/ruff-action@v1
 
   pytest:
     name: pytest (${{ matrix.os[1] }}-py${{ matrix.python-version }})

--- a/.github/workflows/ci_update_dependencies.yml
+++ b/.github/workflows/ci_update_dependencies.yml
@@ -24,6 +24,5 @@ jobs:
       update_pre-commit: true
       python_version: "3.9"
       install_extras: "[pre-commit]"
-      skip_pre-commit_hooks: "pylint,pylint-tests"
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,11 @@ repos:
     - id: trailing-whitespace
       args: [--markdown-linebreak-ext=md]
 
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.12.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.292
     hooks:
-    - id: isort
-      args: ["--profile", "black", "--filter-files", "--skip-gitignore"]
+    - id: ruff
+      args: ["--fix", "--exit-non-zero-on-fix"]
 
   - repo: https://github.com/ambv/black
     rev: 23.9.1
@@ -50,28 +50,3 @@ repos:
       - "--package-dir=oteapi_optimade"
       - "--full-docs-folder=models"
     - id: docs-landing-page
-
-  - repo: local
-    hooks:
-    - id: pylint
-      name: pylint
-      entry: pylint
-      args:
-      - "--rcfile=pyproject.toml"
-      - "--extension-pkg-whitelist='pydantic'"
-      language: python
-      types: [python]
-      require_serial: true
-      files: ^.*$
-      exclude: ^tests/.*$
-    - id: pylint-tests
-      name: pylint - tests
-      entry: pylint
-      args:
-      - "--rcfile=pyproject.toml"
-      - "--extension-pkg-whitelist='pydantic'"
-      - "--disable=import-outside-toplevel,redefined-outer-name"
-      language: python
-      types: [python]
-      require_serial: true
-      files: ^tests/.*$

--- a/oteapi_optimade/dlite/parse.py
+++ b/oteapi_optimade/dlite/parse.py
@@ -1,5 +1,4 @@
 """OTEAPI strategy for parsing OPTIMADE structure resources to DLite instances."""
-# pylint: disable=invalid-name,too-many-branches,too-many-statements
 import logging
 import sys
 from pathlib import Path
@@ -177,7 +176,7 @@ class OPTIMADEDLiteParseStrategy:
                     "'optimade_response' was expected to be present in the session."
                 )
 
-            if not session.optimade_response or not "data" in session.optimade_response:
+            if not session.optimade_response or "data" not in session.optimade_response:
                 LOGGER.debug("Not a successful response - no 'data' entry found.")
                 return session
 

--- a/oteapi_optimade/models/custom_types.py
+++ b/oteapi_optimade/models/custom_types.py
@@ -46,7 +46,7 @@ LOGGER.setLevel(logging.DEBUG)
 
 def optimade_base_url_regex() -> "Pattern[str]":
     """A regular expression for an OPTIMADE base URL."""
-    global _OPTIMADE_BASE_URL_REGEX  # pylint: disable=global-statement
+    global _OPTIMADE_BASE_URL_REGEX
     if _OPTIMADE_BASE_URL_REGEX is None:
         _OPTIMADE_BASE_URL_REGEX = re.compile(
             r"^(?P<base_url>"
@@ -68,7 +68,7 @@ def optimade_base_url_regex() -> "Pattern[str]":
 
 def optimade_endpoint_regex() -> "Pattern[str]":
     """A regular expression for an OPTIMADE base URL."""
-    global _OPTIMADE_ENDPOINT_REGEX  # pylint: disable=global-statement
+    global _OPTIMADE_ENDPOINT_REGEX
     if _OPTIMADE_ENDPOINT_REGEX is None:
         _OPTIMADE_ENDPOINT_REGEX = re.compile(
             # version
@@ -94,7 +94,7 @@ class OPTIMADEUrl(str):
 
     strip_whitespace = True
     min_length = 1
-    # https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers  # pylint: disable=line-too-long
+    # https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
     max_length = 2083
     allowed_schemes = {"http", "https"}
     tld_required = False
@@ -114,7 +114,7 @@ class OPTIMADEUrl(str):
     def __new__(cls, url: "Optional[str]" = None, **kwargs) -> object:
         return str.__new__(
             cls,
-            cls.build(**kwargs) if url is None else url,  # pylint: disable=missing-kwoa
+            cls.build(**kwargs) if url is None else url,
         )
 
     def __init__(

--- a/oteapi_optimade/models/query.py
+++ b/oteapi_optimade/models/query.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, EmailStr, Field
 
 QUERY_PARAMETERS = EntryListingQueryParams()
 """Entry listing URL query parameters from the `optimade` package
-([`EntryListingQueryParams`](https://www.optimade.org/optimade-python-tools/api_reference/server/query_params/#optimade.server.query_params.EntryListingQueryParams))."""  # pylint: disable=line-too-long
+([`EntryListingQueryParams`](https://www.optimade.org/optimade-python-tools/api_reference/server/query_params/#optimade.server.query_params.EntryListingQueryParams))."""
 
 
 class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
@@ -87,10 +87,6 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
         """Generate a valid URL query string based on the set fields."""
         res = {}
         for field, value in self.dict().items():
-            if (
-                value
-                or field
-                in self.__fields_set__  # pylint: disable=unsupported-membership-test
-            ):
+            if value or field in self.__fields_set__:
                 res[field] = unquote(value) if isinstance(value, str) else value
         return urlencode(res, quote_via=quote)

--- a/oteapi_optimade/strategies/filter.py
+++ b/oteapi_optimade/strategies/filter.py
@@ -100,7 +100,7 @@ class OPTIMADEFilterStrategy:
             },
         )
 
-    def get(  # pylint: disable=unused-argument
+    def get(
         self,
         session: "Optional[Dict[str, Any]]" = None,
     ) -> SessionUpdate:

--- a/oteapi_optimade/strategies/parse.py
+++ b/oteapi_optimade/strategies/parse.py
@@ -45,9 +45,7 @@ class OPTIMADEParseStrategy:
 
     parse_config: OPTIMADEParseConfig
 
-    def initialize(  # pylint: disable=unused-argument
-        self, session: "Optional[Dict[str, Any]]" = None
-    ) -> SessionUpdate:
+    def initialize(self, session: "Optional[Dict[str, Any]]" = None) -> SessionUpdate:
         """Initialize strategy.
 
         This method will be called through the `/initialize` endpoint of the OTE-API
@@ -63,7 +61,7 @@ class OPTIMADEParseStrategy:
         """
         return SessionUpdate()
 
-    def get(  # pylint: disable=too-many-branches
+    def get(
         self, session: "Optional[Union[SessionUpdate, Dict[str, Any]]]" = None
     ) -> OPTIMADEParseSession:
         """Request and parse an OPTIMADE response using OPT.

--- a/oteapi_optimade/strategies/resource.py
+++ b/oteapi_optimade/strategies/resource.py
@@ -88,7 +88,7 @@ class OPTIMADEResourceStrategy:
 
     resource_config: OPTIMADEResourceConfig
 
-    def initialize(  # pylint: disable=unused-argument
+    def initialize(
         self, session: "Optional[Dict[str, Any]]" = None
     ) -> "Union[SessionUpdate, DLiteSessionUpdate]":
         """Initialize strategy.
@@ -111,7 +111,7 @@ class OPTIMADEResourceStrategy:
             return DLiteSessionUpdate(collection_id=get_collection(session).uuid)
         return SessionUpdate()
 
-    def get(  # pylint: disable=too-many-branches,too-many-statements
+    def get(
         self, session: "Optional[Union[SessionUpdate, Dict[str, Any]]]" = None
     ) -> OPTIMADEResourceSession:
         """Execute an OPTIMADE query to `accessUrl`.
@@ -210,13 +210,14 @@ class OPTIMADEResourceStrategy:
             self.resource_config.configuration.use_dlite,
         )
 
-        parse_mediaType = f"application/vnd.{self.resource_config.accessService.split('+', maxsplit=1)[0]}"  # pylint: disable=invalid-name,line-too-long
+        parse_mediaType = (
+            "application/vnd."
+            f"{self.resource_config.accessService.split('+', maxsplit=1)[0]}"
+        )
         if parse_with_dlite:
-            parse_mediaType += "+DLite"  # pylint: disable=invalid-name
+            parse_mediaType += "+DLite"
         elif optimade_query.response_format:
-            parse_mediaType += (  # pylint: disable=invalid-name
-                f"+{optimade_query.response_format}"
-            )
+            parse_mediaType += f"+{optimade_query.response_format}"
 
         parse_config = {
             "downloadUrl": optimade_url,

--- a/oteapi_optimade/utils.py
+++ b/oteapi_optimade/utils.py
@@ -34,7 +34,7 @@ def model2dict(
         if isinstance(model_, dict):
             return {key: _internal(value) for key, value in model_.items()}
         if isinstance(model_, Iterable) and not isinstance(model_, (bytes, str)):
-            return type(model_)(_internal(value) for value in model_)  # type: ignore[call-arg]  # pylint: disable=line-too-long
+            return type(model_)(_internal(value) for value in model_)  # type: ignore[call-arg]
         if isinstance(model_, BaseModel):
             return _internal(model_.dict(**dict_kwargs))
         return model_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ test = [
 ]
 pre-commit = [
     "pre-commit ~=3.4",
-    "pylint ~=2.17",
 ]
 dev = [
     "mike ~=1.1",
@@ -69,7 +68,6 @@ dev = [
     "jupyter ~=1.0",
     "otelib ~=0.3",
     "pre-commit ~=3.4",
-    "pylint ~=2.17",
     "pytest ~=7.4",
     "pytest-cov ~=4.1",
     "pyyaml ~=6.0",
@@ -139,15 +137,6 @@ warn_unused_configs = true
 show_error_codes = true
 allow_redefinition = true
 plugins = ["pydantic.mypy"]
-
-[tool.pylint.messages_control]
-max-line-length = 90
-disable = [
-    "duplicate-code",
-    "no-name-in-module",
-    "too-few-public-methods",
-    "no-self-argument"
-]
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def pytest_configure(config) -> None:  # pylint: disable=unused-argument
+def pytest_configure(config) -> None:
     """Method that runs before pytest collects tests, so no modules are imported."""
     import os
     from pathlib import Path

--- a/tests/strategies/test_resource.py
+++ b/tests/strategies/test_resource.py
@@ -85,7 +85,7 @@ def test_use_dlite(
     resource_config: dict[str, str],
     static_files: "Path",
     requests_mock: "Mocker",
-    accessService: str,  # pylint: disable=invalid-name
+    accessService: str,
     use_dlite: bool,
 ) -> None:
     """Test the `get()` method - session is `None` and use_dlite is True."""


### PR DESCRIPTION
Closes #156 

What's being done:
- Remove all `# pylint: disable=...` statements in the code. 
- Remove `pylint` as a dependency.
- Remove `pylint` and `isort` pre-commit hooks, replace with a `ruff` hook.
- Don't run `pylint` in CI, add `ruff` CI job.
- Remove `pylint` configuration from `pyproject.toml`.