### PR TITLE
Proper use of logging

### DIFF
--- a/oteapi_optimade/dlite/parse.py
+++ b/oteapi_optimade/dlite/parse.py
@@ -22,8 +22,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 LOGGER = logging.getLogger("oteapi_optimade.dlite")
-LOGGER.setLevel(logging.DEBUG)
-LOGGER.addHandler(logging.StreamHandler(sys.stdout))
 
 
 @dataclass

--- a/oteapi_optimade/dlite/parse.py
+++ b/oteapi_optimade/dlite/parse.py
@@ -1,6 +1,5 @@
 """OTEAPI strategy for parsing OPTIMADE structure resources to DLite instances."""
 import logging
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 

--- a/oteapi_optimade/models/custom_types.py
+++ b/oteapi_optimade/models/custom_types.py
@@ -41,7 +41,6 @@ _OPTIMADE_BASE_URL_REGEX = None
 _OPTIMADE_ENDPOINT_REGEX = None
 
 LOGGER = logging.getLogger("oteapi_optimade.models")
-LOGGER.setLevel(logging.DEBUG)
 
 
 def optimade_base_url_regex() -> "Pattern[str]":

--- a/oteapi_optimade/strategies/filter.py
+++ b/oteapi_optimade/strategies/filter.py
@@ -1,6 +1,5 @@
 """Demo filter strategy."""
 import logging
-import sys
 from typing import TYPE_CHECKING
 
 from oteapi.models import SessionUpdate

--- a/oteapi_optimade/strategies/filter.py
+++ b/oteapi_optimade/strategies/filter.py
@@ -15,8 +15,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 LOGGER = logging.getLogger("oteapi_optimade.strategies")
-LOGGER.setLevel(logging.DEBUG)
-LOGGER.addHandler(logging.StreamHandler(sys.stdout))
 
 
 @dataclass

--- a/oteapi_optimade/strategies/parse.py
+++ b/oteapi_optimade/strategies/parse.py
@@ -21,8 +21,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 LOGGER = logging.getLogger("oteapi_optimade.strategies")
-LOGGER.setLevel(logging.DEBUG)
-LOGGER.addHandler(logging.StreamHandler(sys.stdout))
 
 
 @dataclass

--- a/oteapi_optimade/strategies/parse.py
+++ b/oteapi_optimade/strategies/parse.py
@@ -1,7 +1,6 @@
 """Demo strategy class for text/json."""
 import json
 import logging
-import sys
 from typing import TYPE_CHECKING
 
 from optimade.models import ErrorResponse, Success

--- a/oteapi_optimade/strategies/resource.py
+++ b/oteapi_optimade/strategies/resource.py
@@ -40,8 +40,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 LOGGER = logging.getLogger("oteapi_optimade.strategies")
-LOGGER.setLevel(logging.DEBUG)
-LOGGER.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def use_dlite(access_service: str, use_dlite_flag: bool) -> bool:

--- a/oteapi_optimade/strategies/resource.py
+++ b/oteapi_optimade/strategies/resource.py
@@ -1,6 +1,5 @@
 """OPTIMADE resource strategy."""
 import logging
-import sys
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs
 


### PR DESCRIPTION
Removed calls to logging setLogger and setHandler - they should not be called by libraries, but by the main application.