### PR TITLE
Semantic mappings for OPTIMADE Structure

### DIFF
--- a/oteapi_optimade/dlite/mappings/OPTIMADEStructureAttributes.yaml
+++ b/oteapi_optimade/dlite/mappings/OPTIMADEStructureAttributes.yaml
@@ -1,0 +1,31 @@
+namespaces:
+  cif: http://emmo.info/CIF-ontology/ontology/cif_core#
+  entity_prop: http://onto-ns.com/meta/1.0/OPTIMADEStructureAttributes#properties.
+  entity_dim: http://onto-ns.com/meta/1.0/OPTIMADEStructureAttributes#dimensions.
+
+mappings:
+  "entity_prop:elements": "cif:_atom_type.element_symbol"
+  "entity_prop:elements_ratios": "cif:"
+  "entity_prop:chemical_formula_descriptive": "cif:"
+  "entity_prop:chemical_formula_reduced": "cif:"
+  "entity_prop:chemical_formula_hill": "cif:_chemical_formula.sum"
+  "entity_prop:chemical_formula_anonymous": "cif:"
+  "entity_prop:dimension_types": "cif:"
+  "entity_prop:nperiodic_dimensions": "cif:"
+  "entity_prop:lattice_vectors": "cif:_cell.orthogonal_matrix"
+  "entity_prop:cartesian_site_positions":
+    - "cif:_atom_site.Cartn_xyz"
+    - "cif:_model_site.Cartn_xyz"
+  # "entity_prop:species": "cif:" See the Species entity mapping
+  "entity_prop:species_at_sites":
+    - "cif:_atom_site.type_symbol"
+    - "cif:_atom_type.symbol"
+  # "entity_prop:assemblies": "cif:" See the Assemblies entity mapping
+  "entity_prop:structure_features": "cif:"
+  "entity_prop:immutable_id": "cif:"
+  "entity_prop:last_modified": "cif:"
+  "entity_dim:nelements": "cif:"
+  "entity_dim:dimensionality": "cif:"
+  "entity_dim:nsites": "cif:"
+  "entity_dim:nspecies": "cif:"
+  "entity_dim:nstructure_features": "cif:"

--- a/oteapi_optimade/dlite/mappings/OPTIMADEStructureSpecies.yaml
+++ b/oteapi_optimade/dlite/mappings/OPTIMADEStructureSpecies.yaml
@@ -1,0 +1,22 @@
+namespaces:
+  cif: http://emmo.info/CIF-ontology/ontology/cif_core#
+  entity_prop: http://onto-ns.com/meta/1.0/OPTIMADEStructureSpecies#properties.
+  entity_dim: http://onto-ns.com/meta/1.0/OPTIMADEStructureSpecies#dimensions.
+
+mappings:
+  "entity_prop:name":
+    - "cif:_atom_site.label"
+    - "cif:_model_site.label"
+  "entity_prop:chemical_symbols":
+    - "cif:_atom_site.type_symbol"
+    - "cif:_atom_type.symbol"
+    - "cif:_model_site.type_symbol"
+  "entity_prop:concentration": "cif:_atom_site.occupancy"
+  "entity_prop:mass":
+    - "cif:_atom_type.atomic_mass"
+    - "cif:_atom_type.analytical_mass_percent"
+  "entity_prop:original_name": "cif:_atom_site.label"
+  "entity_prop:attached": "cif:"
+  "entity_prop:nattached": "cif:_atom_site.attached_hydrogens"
+  "entity_dim:nelements": "cif:"
+  "entity_dim:nattached_elements": "cif:"


### PR DESCRIPTION
Closes #153

Adds semantic mappings for OPTIMADE Structure data models:

- **INITIAL** - Attributes
- **INITIAL** - Species
- **NOT STARTED** - Assemblies

The mappings are currently in a non-official format, written out in a YAML file with two top-level keys: `namespaces` and `mappings`.
The mappings reference namespaces and maps individual entity properties and dimensions to one or more concepts in the CIF ontology.