### PR TITLE
Pin oteapi docker image to pre-pydantic v2

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -136,7 +136,9 @@ jobs:
         .github/utils/wait_for_it.sh localhost:${OTEAPI_PORT} -t 240
         sleep 5
       env:
-        DOCKER_OTEAPI_VERSION: latest
+        # Pin to 1.20231108.329 until #163 has been closed.
+        # Related issue: https://github.com/SINTEF/oteapi-optimade/issues/187
+        DOCKER_OTEAPI_VERSION: '1.20231108.329'
 
     - name: Run end-2-end tests
       run: python .github/utils/end2end_test.py

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -80,12 +80,16 @@ docker run \
     --env OTEAPI_INCLUDE_REDISADMIN=False \
     --env OTEAPI_EXPOSE_SECRETS=True \
     --env OTEAPI_PLUGIN_PACKAGES=oteapi-optimade \
-    ghcr.io/emmc-asbl/oteapi:latest
+    ghcr.io/emmc-asbl/oteapi:1.20231108.329
 ```
 
 !!! note
     To use the `/triples` endpoint, an AllegroGraph triplestore needs to be running.
     For more information see the [OTEAPI Services README](https://github.com/EMMC-ASBL/oteapi-services#run-a-triplestore-allegrograph) to see how to set this up and run it.
+
+!!! important
+    Pinning to version '1.20231108.329' of the OTEAPI image is important, as the latest version is currently not compatible with this plugin.
+    To follow this issue, please see [GitHub issue #187](https://github.com/SINTEF/oteapi-optimade/issues/187) and [GitHub issue #163](https://github.com/SINTEF/oteapi-optimade/issues/163).
 
 #### Using Docker Compose
 


### PR DESCRIPTION
Fixes #187.

This is a temporary fix to be reverted once #182 is merged and #163 is closed.