### PR TITLE
Cap DLite-Python version at 0.5.23 due to SegFault

### DIFF
--- a/.github/utils/requirements_upload.txt
+++ b/.github/utils/requirements_upload.txt
@@ -1,1 +1,1 @@
-entities-service[cli] @ git+https://github.com/SINTEF/entities-service.git@v0.7.0
+entities-service[cli] @ git+https://github.com/SINTEF/entities-service.git@v0.7.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
+    rev: v3.19.1
     hooks:
     - id: pyupgrade
       args: [--py39-plus, --keep-runtime-typing]
@@ -50,20 +50,20 @@ repos:
         additional_dependencies: [black]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.0
+    rev: v0.8.6
     hooks:
     - id: ruff
       args: ["--fix", "--exit-non-zero-on-fix", "--show-fixes"]
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.10
+    rev: 1.8.0
     hooks:
     - id: bandit
       args: ["-r"]
       files: ^oteapi_optimade/.*$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.14.1
     hooks:
     - id: mypy
       exclude: ^tests/.*$
@@ -84,7 +84,7 @@ repos:
   # More information can be found in the repository README:
   # https://github.com/SINTEF/entities-service?tab=readme-ov-file#readme
   - repo: https://github.com/SINTEF/entities-service
-    rev: v0.7.1
+    rev: v0.7.2
     hooks:
     - id: validate-entities
       additional_dependencies: [".[cli]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,13 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
 ]
-keywords = ["OTE", "OPTIMADE", "OTE-API"]
-requires-python = ">=3.9,<3.13"
+keywords = ["OTE", "OPTIMADE", "OTEAPI"]
+requires-python = ">=3.9"
 dynamic = ["version"]
 
 dependencies = [
-    "DLite-Python >=0.5.16,<1",
+    # Pytest runs, end in Segmentation Fault for dlite-python versions >0.5.23
+    "DLite-Python <=0.5.23; python_version<'3.13'",  # DLite is not yet compatible with Python 3.13
     "eval-type-backport ~=0.2.0",
     "numpy <2",  # Required by DLite-Python
     "optimade[server] ~=1.1",


### PR DESCRIPTION
And update pre-commit hooks.

## Copilot summary

This pull request includes updates to the `.pre-commit-config.yaml` file and modifications to the `pyproject.toml` file. The most important changes involve updating dependencies and adjusting compatibility requirements.

Dependency updates in `.pre-commit-config.yaml`:

* Updated `pyupgrade` to version `v3.19.1`.
* Updated `ruff-pre-commit` to version `v0.8.6`.
* Updated `bandit` to version `1.8.0`.
* Updated `mypy` to version `v1.14.1`.
* Updated `validate-entities` to version `v0.7.2`.

Compatibility adjustments in `pyproject.toml`:

* Changed `keywords` from "OTE-API" to "OTEAPI".
* Removed the upper limit for `requires-python`.
* Limited `DLite-Python` to versions `<=0.5.23` due to compatibility issues with Python 3.13.