### PR TITLE
Support OPTIMADE v1.2.0

### DIFF
--- a/entities/OPTIMADEStructure.yaml
+++ b/entities/OPTIMADEStructure.yaml
@@ -1,4 +1,4 @@
-uri: http://onto-ns.com/meta/1.0.1/OPTIMADEStructure
+uri: http://onto-ns.com/meta/1.2.0/OPTIMADEStructure
 meta: http://onto-ns.com/meta/0.3/EntitySchema
 description: An OPTIMADE structure.
 dimensions: {}
@@ -8,7 +8,7 @@ properties:
     description: The name of the type of an entry. Must always be 'structures'.
   attributes:
     type: ref
-    $ref: http://onto-ns.com/meta/1.0.1/OPTIMADEStructureAttributes
+    $ref: http://onto-ns.com/meta/1.2.0/OPTIMADEStructureAttributes
     description: The attributes used to represent a structure, e.g. unit cell, atoms, positions.
   id:
     type: str

--- a/entities/OPTIMADEStructureAttributes.yaml
+++ b/entities/OPTIMADEStructureAttributes.yaml
@@ -1,10 +1,11 @@
-uri: http://onto-ns.com/meta/1.0.1/OPTIMADEStructureAttributes
+uri: http://onto-ns.com/meta/1.2.0/OPTIMADEStructureAttributes
 meta: http://onto-ns.com/meta/0.3/EntitySchema
 description: The attributes used to represent a structure, e.g. unit cell, atoms, positions.
 dimensions:
   nelements: Number of different elements in the structure as an integer.
   dimensionality: Number of spatial dimensions. Must always be 3.
   nsites: An integer specifying the length of the `cartesian_site_positions` property.
+  nspace_group_symmetry_operations: Number of space group symmetry operations.
   nspecies: Number of species.
   nstructure_features: Number of structure features.
 properties:
@@ -40,6 +41,22 @@ properties:
     shape: [dimensionality, dimensionality]
     unit: Å
     description: The three lattice vectors in Cartesian coordinates, in ångström (Å).
+  space_group_symmetry_operations_xyz:
+    type: string
+    shape: [nspace_group_symmetry_operations]
+    description: List of symmetry operations given as general position x, y and z coordinates in algebraic form.
+  space_group_symbol_hall:
+    type: string
+    description: A Hall space group symbol representing the symmetry of the structure as defined in (Hall, 1981, 1981a).
+  space_group_symbol_hermann_mauguin:
+    type: string
+    description: A human- and machine-readable string containing the short Hermann-Mauguin (H-M) symbol which specifies the space group of the structure in the response.
+  space_group_symbol_hermann_mauguin_extended:
+    type: string
+    description: A human- and machine-readable string containing the extended Hermann-Mauguin (H-M) symbol which specifies the space group of the structure in the response.
+  space_group_it_number:
+    type: int
+    description: Space group number which specifies the space group of the structure as defined in the International Tables for Crystallography Vol. A. (IUCr, 2005).
   cartesian_site_positions:
     type: float
     shape: [nsites, dimensionality]

--- a/entities/OPTIMADEStructureResource.yaml
+++ b/entities/OPTIMADEStructureResource.yaml
@@ -1,12 +1,11 @@
-uri: http://onto-ns.com/meta/1.0.1/OPTIMADEStructureResource
+uri: http://onto-ns.com/meta/1.2.0/OPTIMADEStructureResource
 description: An OPTIMADE structure resource.
 dimensions:
   nelements: Number of different elements in the structure as an integer.
   dimensionality: Number of spatial dimensions. Must always be 3.
   nsites: An integer specifying the length of the `cartesian_site_positions` property.
   nstructure_features: Number of structure features.
-  ## Uncomment when space_group attributes are implemented in OPT.
-  # nspace_group_symmetry_operations: Number of space group symmetry operations.
+  nspace_group_symmetry_operations: Number of space group symmetry operations.
   nspecies: Number of species.
   nassemblies: Number of assemblies.
 properties:
@@ -59,23 +58,22 @@ properties:
     shape: [dimensionality, dimensionality]
     unit: Å
     description: The three lattice vectors in Cartesian coordinates, in ångström (Å).
-  ## Uncomment when space_group attributes are implemented in OPT.
-  # space_group_symmetry_operations_xyz:
-  #   type: string
-  #   shape: [nspace_group_symmetry_operations]
-  #   description: List of symmetry operations given as general position x, y and z coordinates in algebraic form.
-  # space_group_symbol_hall:
-  #   type: string
-  #   description: A Hall space group symbol representing the symmetry of the structure as defined in (Hall, 1981, 1981a).
-  # space_group_symbol_hermann_mauguin:
-  #   type: string
-  #   description: A human- and machine-readable string containing the short Hermann-Mauguin (H-M) symbol which specifies the space group of the structure in the response.
-  # space_group_symbol_hermann_mauguin_extended:
-  #   type: string
-  #   description: A human- and machine-readable string containing the extended Hermann-Mauguin (H-M) symbol which specifies the space group of the structure in the response.
-  # space_group_it_number:
-  #   type: int
-  #   description: Space group number which specifies the space group of the structure as defined in the International Tables for Crystallography Vol. A. (IUCr, 2005).
+  space_group_symmetry_operations_xyz:
+    type: string
+    shape: [nspace_group_symmetry_operations]
+    description: List of symmetry operations given as general position x, y and z coordinates in algebraic form.
+  space_group_symbol_hall:
+    type: string
+    description: A Hall space group symbol representing the symmetry of the structure as defined in (Hall, 1981, 1981a).
+  space_group_symbol_hermann_mauguin:
+    type: string
+    description: A human- and machine-readable string containing the short Hermann-Mauguin (H-M) symbol which specifies the space group of the structure in the response.
+  space_group_symbol_hermann_mauguin_extended:
+    type: string
+    description: A human- and machine-readable string containing the extended Hermann-Mauguin (H-M) symbol which specifies the space group of the structure in the response.
+  space_group_it_number:
+    type: int
+    description: Space group number which specifies the space group of the structure as defined in the International Tables for Crystallography Vol. A. (IUCr, 2005).
   cartesian_site_positions:
     type: float
     shape: [nsites, dimensionality]

--- a/oteapi_optimade/dlite/parse.py
+++ b/oteapi_optimade/dlite/parse.py
@@ -386,6 +386,13 @@ class OPTIMADEDLiteParseStrategy:
                         "nstructure_features": len(
                             structure.attributes.structure_features
                         ),
+                        "nspace_group_symmetry_operations": (
+                            len(
+                                structure.attributes.space_group_symmetry_operations_xyz
+                            )
+                            if structure.attributes.space_group_symmetry_operations_xyz
+                            else 0
+                        ),
                         **single_entity_dimensions,
                     },
                     properties=new_structure_attributes,
@@ -413,6 +420,13 @@ class OPTIMADEDLiteParseStrategy:
                                 ),
                                 "nstructure_features": len(
                                     structure.attributes.structure_features
+                                ),
+                                "nspace_group_symmetry_operations": (
+                                    len(
+                                        structure.attributes.space_group_symmetry_operations_xyz
+                                    )
+                                    if structure.attributes.space_group_symmetry_operations_xyz
+                                    else 0
                                 ),
                             },
                             properties=new_structure_attributes,

--- a/oteapi_optimade/strategies/resource.py
+++ b/oteapi_optimade/strategies/resource.py
@@ -213,7 +213,7 @@ class OPTIMADEResourceStrategy:
             parse_mediaType += f"+{optimade_query.response_format}"
 
         parse_config: ParseConfigDict = {
-            "entity": "http://onto-ns.com/meta/1.0.1/OPTIMADEStructure",
+            "entity": "http://onto-ns.com/meta/1.2.0/OPTIMADEStructure",
             "parserType": parse_parserType,
             "configuration": {
                 "datacache_config": self.resource_config.configuration.datacache_config.model_copy(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,4 +158,7 @@ addopts = "-rs --cov=oteapi_optimade --cov-report=term-missing:skip-covered --no
 filterwarnings = [
     # Fail on any warning
     "error",
+
+    # Ignore pydantic warning emitted from OPT as of pydantic v2.11
+    "ignore:.*Accessing this attribute on the instance is deprecated.*:pydantic.warnings.PydanticDeprecatedSince211",
 ]

--- a/tests/dlite/test_parse.py
+++ b/tests/dlite/test_parse.py
@@ -52,7 +52,7 @@ def test_parse_nested_entities(static_files: Path) -> None:
         '?filter=elements HAS ALL "Si","O"&sort=nelements&page_limit=2'
     )
     config = {
-        "entity": "http://onto-ns.com/meta/1.0.1/OPTIMADEStructure",
+        "entity": "http://onto-ns.com/meta/1.2.0/OPTIMADEStructure",
         "parserType": "parser/OPTIMADE/DLite",
         "configuration": {
             "mediaType": "application/vnd.OPTIMADE+DLite",
@@ -95,6 +95,8 @@ def test_parse_nested_entities(static_files: Path) -> None:
 
         dlite_structure: Instance = dlite_collection[optimade_structure.id]
 
+        print(dlite_structure.attributes)
+
         ## Go over other top-level non-container keys in the OPTIMADE structure
         assert dlite_structure.type == optimade_structure.type
 
@@ -103,7 +105,7 @@ def test_parse_nested_entities(static_files: Path) -> None:
         # Avoid attributes with special model values for now
         model_values = ("assemblies", "species")
 
-        for field in optimade_structure.attributes.model_fields:
+        for field in optimade_structure.attributes.__class__.model_fields:
             if field in model_values:
                 continue
 
@@ -118,6 +120,12 @@ def test_parse_nested_entities(static_files: Path) -> None:
                     expected_value = [
                         value.isoformat(sep=" ") for value in expected_value
                     ]
+
+            if expected_value is None:
+                if field == "space_group_symmetry_operations_xyz":
+                    expected_value = []
+                elif field == "space_group_it_number":
+                    expected_value = 0
 
             if isinstance(expected_value, Enum):
                 expected_value = expected_value.value
@@ -149,7 +157,7 @@ def test_parse_nested_entities(static_files: Path) -> None:
             for i, entry in enumerate(getattr(dlite_structure.attributes, field)):
                 for sub_field in getattr(optimade_structure.attributes, field)[
                     0
-                ].model_fields:
+                ].__class__.model_fields:
                     expected_sub_value = getattr(expected_value[i], sub_field)
                     dlite_sub_value = getattr(entry, sub_field)
 
@@ -234,7 +242,7 @@ def test_parse_single_entity(static_files: Path) -> None:
         '?filter=elements HAS ALL "Si","O"&sort=nelements&page_limit=2'
     )
     config = {
-        "entity": "http://onto-ns.com/meta/1.0.1/OPTIMADEStructureResource",
+        "entity": "http://onto-ns.com/meta/1.2.0/OPTIMADEStructureResource",
         "parserType": "parser/OPTIMADE/DLite",
         "configuration": {
             "mediaType": "application/vnd.OPTIMADE+DLite",
@@ -285,7 +293,7 @@ def test_parse_single_entity(static_files: Path) -> None:
         # Avoid attributes with special model values for now
         model_values = ("assemblies", "species")
 
-        for field in optimade_structure.attributes.model_fields:
+        for field in optimade_structure.attributes.__class__.model_fields:
             if field in model_values:
                 continue
 
@@ -300,6 +308,12 @@ def test_parse_single_entity(static_files: Path) -> None:
                     expected_value = [
                         value.isoformat(sep=" ") for value in expected_value
                     ]
+
+            if expected_value is None:
+                if field == "space_group_symmetry_operations_xyz":
+                    expected_value = []
+                elif field == "space_group_it_number":
+                    expected_value = 0
 
             if isinstance(expected_value, Enum):
                 expected_value = expected_value.value
@@ -339,7 +353,7 @@ def test_parse_single_entity(static_files: Path) -> None:
             for i, entry in enumerate(parsed_value):
                 for sub_field in getattr(optimade_structure.attributes, field)[
                     0
-                ].model_fields:
+                ].__class__.model_fields:
                     expected_sub_value = getattr(expected_value[i], sub_field)
                     dlite_sub_value = entry.get(sub_field)
 


### PR DESCRIPTION
At least concerning the updated Structure resource model.

## AI Summary

This pull request includes updates to the OPTIMADE structure schema and attributes, along with corresponding changes in the parsing logic and tests. The most important changes include updating the schema URIs to version 1.2.0, adding new attributes related to space group symmetry operations, and modifying the parsing and testing code to accommodate these changes.

Schema updates:

* Updated schema URIs to version 1.2.0 in `entities/OPTIMADEStructure.yaml`, `entities/OPTIMADEStructureAttributes.yaml`, and `entities/OPTIMADEStructureResource.yaml`. [[1]](diffhunk://#diff-2826c7ee68bc34ba5ff2f64cbd107f20a55a2e6cbd0729f5677de1f614092c53L1-R1) [[2]](diffhunk://#diff-2826c7ee68bc34ba5ff2f64cbd107f20a55a2e6cbd0729f5677de1f614092c53L11-R11) [[3]](diffhunk://#diff-2d34a666120fe54709f424d2199078a769ed2d15c568841e590fb5caff261db9L1-R8) [[4]](diffhunk://#diff-15e05fe0b1337a2fa6c8aa3b50d07a36007af347aa425471da42f572005033d4L1-R8) [[5]](diffhunk://#diff-b13a14a0a531b3a3375544fbbc3cd0195fea297c5555be9997cd2a323ff8f7c4L216-R216) [[6]](diffhunk://#diff-db44b0e3c4c7caf20d3a792a9b3902a4ec9dfd2f60f94fef9f856cb81f0b9882L55-R55) [[7]](diffhunk://#diff-db44b0e3c4c7caf20d3a792a9b3902a4ec9dfd2f60f94fef9f856cb81f0b9882L237-R245)
* Added new attributes related to space group symmetry operations in `entities/OPTIMADEStructureAttributes.yaml` and `entities/OPTIMADEStructureResource.yaml`. [[1]](diffhunk://#diff-2d34a666120fe54709f424d2199078a769ed2d15c568841e590fb5caff261db9R44-R59) [[2]](diffhunk://#diff-15e05fe0b1337a2fa6c8aa3b50d07a36007af347aa425471da42f572005033d4L62-R76)

Parsing logic updates:

* Modified the `get` method in `oteapi_optimade/dlite/parse.py` to include the new `nspace_group_symmetry_operations` attribute. [[1]](diffhunk://#diff-9ccaeb13eecd2e3da854e67f9e74b035aa24b1f29b162205c9309d98c9b2af68R389-R395) [[2]](diffhunk://#diff-9ccaeb13eecd2e3da854e67f9e74b035aa24b1f29b162205c9309d98c9b2af68R424-R430)

Testing updates:

* Updated tests in `tests/dlite/test_parse.py` to reflect the new schema URIs and handle the new attributes. [[1]](diffhunk://#diff-db44b0e3c4c7caf20d3a792a9b3902a4ec9dfd2f60f94fef9f856cb81f0b9882R98-R99) [[2]](diffhunk://#diff-db44b0e3c4c7caf20d3a792a9b3902a4ec9dfd2f60f94fef9f856cb81f0b9882L106-R108) [[3]](diffhunk://#diff-db44b0e3c4c7caf20d3a792a9b3902a4ec9dfd2f60f94fef9f856cb81f0b9882R124-R129) [[4]](diffhunk://#diff-db44b0e3c4c7caf20d3a792a9b3902a4ec9dfd2f60f94fef9f856cb81f0b9882L152-R160) [[5]](diffhunk://#diff-db44b0e3c4c7caf20d3a792a9b3902a4ec9dfd2f60f94fef9f856cb81f0b9882L288-R296) [[6]](diffhunk://#diff-db44b0e3c4c7caf20d3a792a9b3902a4ec9dfd2f60f94fef9f856cb81f0b9882R312-R317) [[7]](diffhunk://#diff-db44b0e3c4c7caf20d3a792a9b3902a4ec9dfd2f60f94fef9f856cb81f0b9882L342-R356)
* Added a warning filter in `pyproject.toml` to ignore a specific pydantic warning.