### PR TITLE
Updates to align with OTE v1 changes

### DIFF
--- a/.github/workflows/ci_bot_pr_change.yml
+++ b/.github/workflows/ci_bot_pr_change.yml
@@ -1,0 +1,45 @@
+name: CI - Update [bot] PR
+
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - 'main'
+
+jobs:
+  add_skip_changelog_label:
+    name: Add 'skip_changelog' label
+    runs-on: ubuntu-latest
+
+    if: github.event.pull_request.user.type == 'Bot'
+
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+    - name: Add 'skip_changelog' label
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const labels = await github.rest.issues.listLabelsOnIssue({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number
+          })
+
+          for (const label of labels.data) {
+            if (label.name === 'skip_changelog') {
+              console.log("Label 'skip_changelog' already exists 👌")
+              return  // Skip adding the label if it already exists
+            }
+          }
+
+          await github.rest.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            labels: ['skip_changelog']
+          })
+          console.log("Label 'skip_changelog' added 🎉")

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -127,7 +127,7 @@ jobs:
           --env "OTEAPI_PLUGIN_PACKAGES=-v -e /oteapi-optimade" \
           --network "host" \
           --volume "${PWD}:/oteapi-optimade" \
-          ghcr.io/emmc-asbl/oteapi:${DOCKER_OTEAPI_VERSION}
+          ghcr.io/emmc-asbl/oteapi:${DOCKER_OTEAPI_VERSION} &
 
         .github/utils/wait_for_it.sh localhost:${OTEAPI_PORT} -t 240
         sleep 5

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install -U setuptools wheel flit
-        pip install -e .[test]
+        pip install -e .[testing]
 
     - name: Test with pytest
       run: pytest -vvv --cov-report=xml

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -23,12 +23,6 @@ jobs:
       run_pylint: false
 
       run_safety: true
-      # ID: 70612
-      #   Package: Jinja2
-      #   Has been disputed by the maintainer and multiple third parties.
-      #   For more information see: https://github.com/advisories/GHSA-f6pv-j8mr-w6rr
-      safety_options: |
-        --ignore=70612
 
       # Build dist
       python_version_package: "3.10"
@@ -47,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os:
         - ["ubuntu-latest", "linux"]
         - ["windows-latest", "windows"]
@@ -129,12 +123,11 @@ jobs:
           --env "OTEAPI_REDIS_TYPE=redis" \
           --env "OTEAPI_REDIS_HOST=localhost" \
           --env "OTEAPI_REDIS_PORT=6379" \
-          --env "OTEAPI_PREFIX=${OTEAPI_PREFIX}" \
+          --env OTEAPI_PREFIX \
+          --env "OTEAPI_PLUGIN_PACKAGES=-v -e /oteapi-optimade" \
           --network "host" \
           --volume "${PWD}:/oteapi-optimade" \
-          --entrypoint "" \
-          ghcr.io/emmc-asbl/oteapi:${DOCKER_OTEAPI_VERSION} \
-          /bin/bash -c "pip install -v -e /oteapi-optimade && ./entrypoint.sh" &
+          ghcr.io/emmc-asbl/oteapi:${DOCKER_OTEAPI_VERSION}
 
         .github/utils/wait_for_it.sh localhost:${OTEAPI_PORT} -t 240
         sleep 5

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,12 @@
+# Default state for all rules
+default: true
+
+# MD013/line-length - Line length
+MD013:
+  # Number of characters
+  # Set very long to support 1-sentence-per-line style.
+  line_length: 999
+  # Number of characters for headings (match that of black's default)
+  heading_line_length: 88
+  # Number of characters for code blocks (match that of black's default)
+  code_block_line_length: 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,8 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
+    - id: check-json
+      name: Check JSON
     - id: check-toml
       name: Check TOML
     - id: check-yaml
@@ -29,11 +31,21 @@ repos:
     - id: trailing-whitespace
       args: [--markdown-linebreak-ext=md]
 
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.17.2
+    hooks:
+    - id: markdownlint-cli2
+      name: markdownlint
+      exclude: ^(docs/)?(index|LICENSE|CHANGELOG).md$
+      args:
+      - --fix
+      - --config=.markdownlint.yaml
+
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.19.1
     hooks:
     - id: pyupgrade
-      args: [--py39-plus, --keep-runtime-typing]
+      args: [--py310-plus]
 
   - repo: https://github.com/psf/black
     rev: 25.1.0

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   oteapi:
-    image: ghcr.io/emmc-asbl/oteapi:${DOCKER_OTEAPI_VERSION:-latest}
+    image: ghcr.io/emmc-asbl/oteapi:${DOCKER_OTEAPI_VERSION:-latest-dev}
     ports:
       - "${OTEAPI_PORT:-8080}:8080"
     environment:
@@ -8,18 +8,13 @@ services:
       OTEAPI_REDIS_HOST: redis
       OTEAPI_REDIS_PORT: 6379
       OTEAPI_PREFIX: "${OTEAPI_PREFIX:-/api/v1}"
-      PATH_TO_OTEAPI_CORE:
       OTEAPI_PLUGIN_PACKAGES: "-v -e /oteapi-optimade"
     depends_on:
       - redis
     networks:
       - otenet
     volumes:
-      - "${PATH_TO_OTEAPI_CORE:-/dev/null}:/oteapi-core"
       - "${PWD}:/oteapi-optimade"
-    entrypoint: |
-      /bin/bash -c "if [ \"${PATH_TO_OTEAPI_CORE}\" != \"/dev/null\" ] && [ -n \"${PATH_TO_OTEAPI_CORE}\" ]; then \
-      pip install -U --force-reinstall -e /oteapi-core; fi && ./entrypoint.sh --reload --debug --log-level debug"
     stop_grace_period: 1s
 
   redis:

--- a/oteapi_optimade/_utils.py
+++ b/oteapi_optimade/_utils.py
@@ -9,13 +9,7 @@ from typing import TYPE_CHECKING
 import dlite
 
 if TYPE_CHECKING:  # pragma: no cover
-    import sys
-    from typing import Any
-
-    if sys.version_info >= (3, 9, 1):
-        from typing import Literal
-    else:
-        from typing_extensions import Literal  # type: ignore[assignment]
+    from typing import Any, Literal
 
 LOGGER = logging.getLogger(__name__)
 

--- a/oteapi_optimade/models/config.py
+++ b/oteapi_optimade/models/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Literal
 
 from oteapi.models import AttrDict, DataCacheConfig
 from pydantic import BeforeValidator, Field, field_validator
@@ -22,12 +22,12 @@ class OPTIMADEConfig(AttrDict):
 
     # OTEAPI-specific attributes
     downloadUrl: Annotated[
-        Optional[OPTIMADEUrl],
+        OPTIMADEUrl | None,
         Field(description="Either a base OPTIMADE URL or a full OPTIMADE URL."),
     ] = None
 
     mediaType: Annotated[
-        Optional[Literal["application/vnd.optimade+json", "application/vnd.optimade"]],
+        Literal["application/vnd.optimade+json", "application/vnd.optimade"] | None,
         BeforeValidator(lambda x: x.lower() if isinstance(x, str) else x),
         Field(
             description="The registered strategy name for OPTIMADEParseStrategy.",
@@ -36,7 +36,7 @@ class OPTIMADEConfig(AttrDict):
 
     # OPTIMADE parse result attributes
     optimade_config: Annotated[
-        Optional[OPTIMADEConfig],
+        OPTIMADEConfig | None,
         Field(description="A pre-existing instance of this OPTIMADE configuration."),
     ] = None
 
@@ -57,7 +57,7 @@ class OPTIMADEConfig(AttrDict):
     ] = "structures"
 
     query_parameters: Annotated[
-        Optional[OPTIMADEQueryParameters],
+        OPTIMADEQueryParameters | None,
         Field(
             description="URL query parameters to be used in the OPTIMADE query.",
         ),
@@ -108,7 +108,7 @@ class OPTIMADEDLiteConfig(OPTIMADEConfig):
 
     # OTEAPI-specific attributes
     mediaType: Annotated[
-        Optional[Literal["application/vnd.optimade+dlite"]],
+        Literal["application/vnd.optimade+dlite"] | None,
         BeforeValidator(lambda x: x.lower() if isinstance(x, str) else x),
         Field(
             description="The registered strategy name for OPTIMADEDLiteParseStrategy.",
@@ -117,6 +117,6 @@ class OPTIMADEDLiteConfig(OPTIMADEConfig):
 
     # Dlite specific attributes
     collection_id: Annotated[
-        Optional[str],
+        str | None,
         Field(description="A reference to a DLite Collection."),
     ] = None

--- a/oteapi_optimade/models/custom_types.py
+++ b/oteapi_optimade/models/custom_types.py
@@ -22,7 +22,7 @@ from pydantic import AnyHttpUrl, ValidationError
 from pydantic_core import Url, core_schema
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any, Optional, TypedDict, Union
+    from typing import Any, TypedDict
 
     from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
     from pydantic.json_schema import JsonSchemaValue
@@ -91,10 +91,10 @@ class OPTIMADEUrl(str):
         self,
         url: str,
         *,
-        base_url: Optional[str] = None,
-        version: Optional[str] = None,
-        endpoint: Optional[str] = None,
-        query: Optional[str] = None,
+        base_url: str | None = None,
+        version: str | None = None,
+        endpoint: str | None = None,
+        query: str | None = None,
     ) -> None:
         str.__init__(url)
 
@@ -115,7 +115,7 @@ class OPTIMADEUrl(str):
                 pydantic_url = None
 
         # Build OPTIMADE URL parts
-        optimade_parts: Union[OPTIMADEParts, dict[str, Any]] = {}
+        optimade_parts: OPTIMADEParts | dict[str, Any] = {}
         if pydantic_url:
             optimade_parts = self._build_optimade_parts(pydantic_url)
 
@@ -145,9 +145,9 @@ class OPTIMADEUrl(str):
     def _build(
         *,
         base_url: str,
-        version: Optional[str] = None,
-        endpoint: Optional[str] = None,
-        query: Optional[str] = None,
+        version: str | None = None,
+        endpoint: str | None = None,
+        query: str | None = None,
     ) -> str:
         """Build complete OPTIMADE URL from URL parts."""
         url = base_url.rstrip("/")
@@ -176,21 +176,21 @@ class OPTIMADEUrl(str):
         return self._base_url
 
     @property
-    def version(self) -> Optional[str]:
+    def version(self) -> str | None:
         """The version part of the OPTIMADE URL."""
         return self._version
 
     @property
-    def endpoint(self) -> Optional[str]:
+    def endpoint(self) -> str | None:
         """The endpoint part of the OPTIMADE URL."""
         return self._endpoint
 
     @property
-    def query(self) -> Optional[str]:
+    def query(self) -> str | None:
         """The query part of the OPTIMADE URL."""
         return self._query
 
-    def response_model(self) -> Union[tuple[Success, Success], Success, None]:
+    def response_model(self) -> tuple[Success, Success] | Success | None:
         """Return the endpoint's corresponding response model(s) (from OPT)."""
         if not self.endpoint or self.endpoint == "versions":
             return None
@@ -265,7 +265,7 @@ class OPTIMADEUrl(str):
         )
 
     @classmethod
-    def _validate_from_str_or_url(cls, value: Union[Url, str]) -> OPTIMADEUrl:
+    def _validate_from_str_or_url(cls, value: Url | str) -> OPTIMADEUrl:
         """Pydantic validation of an OPTIMADE URL."""
         # Parse as URL
         url = AnyHttpUrl(str(value))

--- a/oteapi_optimade/models/query.py
+++ b/oteapi_optimade/models/query.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Annotated, Optional
+from typing import Annotated
 from urllib.parse import quote, unquote, urlencode
 
 from optimade.server.query_params import EntryListingQueryParams
@@ -27,7 +27,7 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
     """Common OPTIMADE entry listing endpoint query parameters."""
 
     filter: Annotated[
-        Optional[str],
+        str | None,
         Field(
             description=QUERY_PARAMETERS["annotations"]["filter"].description,
         ),
@@ -35,7 +35,7 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
         QUERY_PARAMETERS["defaults"].filter or None
     )
     response_format: Annotated[
-        Optional[str],
+        str | None,
         Field(
             description=QUERY_PARAMETERS["annotations"]["response_format"].description,
         ),
@@ -43,7 +43,7 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
         QUERY_PARAMETERS["defaults"].response_format or None
     )
     email_address: Annotated[
-        Optional[EmailStr],
+        EmailStr | None,
         Field(
             description=QUERY_PARAMETERS["annotations"]["email_address"].description,
         ),
@@ -51,7 +51,7 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
         QUERY_PARAMETERS["defaults"].email_address or None
     )
     response_fields: Annotated[
-        Optional[str],
+        str | None,
         Field(
             description=QUERY_PARAMETERS["annotations"]["response_fields"].description,
             pattern=QUERY_PARAMETERS["annotations"]["response_fields"]
@@ -62,7 +62,7 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
         QUERY_PARAMETERS["defaults"].response_fields or None
     )
     sort: Annotated[
-        Optional[str],
+        str | None,
         Field(
             description=QUERY_PARAMETERS["annotations"]["sort"].description,
             pattern=QUERY_PARAMETERS["annotations"]["sort"].metadata[0].pattern,
@@ -71,7 +71,7 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
         QUERY_PARAMETERS["defaults"].sort or None
     )
     page_limit: Annotated[
-        Optional[int],
+        int | None,
         Field(
             description=QUERY_PARAMETERS["annotations"]["page_limit"].description,
             ge=QUERY_PARAMETERS["annotations"]["page_limit"].metadata[0].ge,
@@ -80,7 +80,7 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
         QUERY_PARAMETERS["defaults"].page_limit or None
     )
     page_offset: Annotated[
-        Optional[int],
+        int | None,
         Field(
             description=QUERY_PARAMETERS["annotations"]["page_offset"].description,
             ge=QUERY_PARAMETERS["annotations"]["page_offset"].metadata[0].ge,
@@ -89,7 +89,7 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
         QUERY_PARAMETERS["defaults"].page_offset or None
     )
     page_number: Annotated[
-        Optional[int],
+        int | None,
         Field(
             description=QUERY_PARAMETERS["annotations"]["page_number"].description,
             # ge=QUERY_PARAMETERS["annotations"]["page_number"].metadata[0].ge,
@@ -100,7 +100,7 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
         QUERY_PARAMETERS["defaults"].page_number or None
     )
     page_cursor: Annotated[
-        Optional[int],
+        int | None,
         Field(
             description=QUERY_PARAMETERS["annotations"]["page_cursor"].description,
             ge=QUERY_PARAMETERS["annotations"]["page_cursor"].metadata[0].ge,
@@ -109,7 +109,7 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
         QUERY_PARAMETERS["defaults"].page_cursor or None
     )
     page_above: Annotated[
-        Optional[int],
+        int | None,
         Field(
             description=QUERY_PARAMETERS["annotations"]["page_above"].description,
         ),
@@ -117,7 +117,7 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
         QUERY_PARAMETERS["defaults"].page_above or None
     )
     page_below: Annotated[
-        Optional[int],
+        int | None,
         Field(
             description=QUERY_PARAMETERS["annotations"]["page_below"].description,
         ),
@@ -125,7 +125,7 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
         QUERY_PARAMETERS["defaults"].page_below or None
     )
     include: Annotated[
-        Optional[str],
+        str | None,
         Field(
             description=QUERY_PARAMETERS["annotations"]["include"].description,
         ),
@@ -135,7 +135,7 @@ class OPTIMADEQueryParameters(BaseModel, validate_assignment=True):
     # api_hint is not yet initialized in `EntryListingQueryParams`.
     # These values are copied verbatim from `optimade==0.16.10`.
     api_hint: Annotated[
-        Optional[str],
+        str | None,
         Field(
             description=(
                 "If the client provides the parameter, the value SHOULD have the format "

--- a/oteapi_optimade/models/strategies/filter.py
+++ b/oteapi_optimade/models/strategies/filter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, Optional
+from typing import Annotated, Any, Literal
 
 from oteapi.models import AttrDict, FilterConfig
 from pydantic import BeforeValidator, ConfigDict, Field
@@ -26,7 +26,7 @@ class OPTIMADEFilterConfig(FilterConfig):
         ),
     ]
     query: Annotated[
-        Optional[str],
+        str | None,
         Field(
             description=(
                 "The `filter` OPTIMADE query parameter value. This parameter value can "
@@ -38,7 +38,7 @@ class OPTIMADEFilterConfig(FilterConfig):
         ),
     ] = None
     limit: Annotated[
-        Optional[int],
+        int | None,
         Field(
             description=(
                 "The `page_limit` OPTIMADE query parameter value. This parameter value can"
@@ -67,7 +67,7 @@ class OPTIMADEFilterResult(AttrDict):
     model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
 
     optimade_config: Annotated[
-        Optional[OPTIMADEConfig],
+        OPTIMADEConfig | None,
         Field(
             description=(
                 "OPTIMADE configuration. Contains relevant information necessary to "
@@ -76,7 +76,7 @@ class OPTIMADEFilterResult(AttrDict):
         ),
     ] = None
     optimade_response_model: Annotated[
-        Optional[tuple[str, str]],
+        tuple[str, str] | None,
         Field(
             description=(
                 "An OPTIMADE Python tools (OPT) pydantic successful response model. "
@@ -86,7 +86,7 @@ class OPTIMADEFilterResult(AttrDict):
         ),
     ] = None
     optimade_response: Annotated[
-        Optional[dict[str, Any]],
+        dict[str, Any] | None,
         Field(
             description="An OPTIMADE response as a Python dictionary.",
         ),

--- a/oteapi_optimade/models/strategies/parse.py
+++ b/oteapi_optimade/models/strategies/parse.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Annotated, Any, Literal, Optional
+from typing import Annotated, Any, Literal
 
 from oteapi.models import AttrDict, ParserConfig
 from pydantic import AnyHttpUrl, BeforeValidator, ConfigDict, Field, field_validator
@@ -65,7 +65,7 @@ class OPTIMADEParseResult(AttrDict):
     model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
 
     optimade_config: Annotated[
-        Optional[OPTIMADEConfig],
+        OPTIMADEConfig | None,
         Field(
             description=(
                 "OPTIMADE configuration. Contains relevant information necessary to "
@@ -74,7 +74,7 @@ class OPTIMADEParseResult(AttrDict):
         ),
     ] = None
     optimade_response_model: Annotated[
-        Optional[tuple[str, str]],
+        tuple[str, str] | None,
         Field(
             description=(
                 "An OPTIMADE Python tools (OPT) pydantic successful response model. "
@@ -84,7 +84,7 @@ class OPTIMADEParseResult(AttrDict):
         ),
     ] = None
     optimade_response: Annotated[
-        Optional[dict[str, Any]],
+        dict[str, Any] | None,
         Field(
             description="An OPTIMADE response as a Python dictionary.",
         ),

--- a/oteapi_optimade/models/strategies/resource.py
+++ b/oteapi_optimade/models/strategies/resource.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, Optional, Union
+from typing import Annotated, Any, Literal
 
 from oteapi.models import AttrDict, ResourceConfig
 from pydantic import BeforeValidator, ConfigDict, Field
@@ -32,7 +32,7 @@ class OPTIMADEResourceConfig(ResourceConfig):
         ),
     ]
     configuration: Annotated[
-        Union[OPTIMADEConfig | OPTIMADEDLiteConfig],
+        OPTIMADEConfig | OPTIMADEDLiteConfig,
         Field(
             description=(
                 "OPTIMADE configuration. Contains relevant information necessary to "
@@ -48,7 +48,7 @@ class OPTIMADEResourceResult(AttrDict):
     model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
 
     optimade_config: Annotated[
-        Optional[OPTIMADEConfig],
+        OPTIMADEConfig | None,
         Field(
             description=(
                 "OPTIMADE configuration. Contains relevant information necessary to "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = "~=3.10"
 dynamic = ["version"]
 
 dependencies = [
-    "DLite-Python ~=0.5.29; python_version<'3.13'",  # DLite is not yet compatible with Python 3.13
+    "DLite-Python ~=0.5.29",  #; python_version<'3.13'",  # DLite is not yet compatible with Python 3.13
     "eval-type-backport ~=0.2.2",
     "optimade[server] ~=1.2",
     "oteapi-core ~=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,13 +50,13 @@ examples = [
     "otelib ~=1.0",
 ]
 pre-commit = ["pre-commit ~=4.2"]
-test = [
+testing = [
     "pytest ~=8.3",
     "pytest-cov ~=6.1",
     "pyyaml ~=6.0",
     "requests-mock ~=1.12",
 ]
-dev = ["oteapi-optimade[docs,examples,pre-commit,test]"]
+dev = ["oteapi-optimade[docs,examples,pre-commit,testing]"]
 
 [project.urls]
 Home = "https://github.com/SINTEF/oteapi-optimade"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     # "Framework :: OTEAPI",
     "Environment :: Plugins",
     "Natural Language :: English",
@@ -27,7 +28,7 @@ requires-python = "~=3.10"
 dynamic = ["version"]
 
 dependencies = [
-    "DLite-Python ~=0.5.29",  #; python_version<'3.13'",  # DLite is not yet compatible with Python 3.13
+    "DLite-Python ~=0.5.29",
     "eval-type-backport ~=0.2.2",
     "optimade[server] ~=1.2",
     "oteapi-core ~=1.0",

--- a/tests/strategies/test_resource.py
+++ b/tests/strategies/test_resource.py
@@ -9,13 +9,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    import sys
     from pathlib import Path
-
-    if sys.version_info >= (3, 10):
-        from typing import Literal
-    else:
-        from typing_extensions import Literal
+    from typing import Literal
 
     from requests_mock import Mocker
 


### PR DESCRIPTION
Several changes have been implemented DX-wise during the upgrade to OTE v1.

These are applied here as well.

## AI Summary

This pull request includes several changes to improve CI workflows, update type annotations, and enhance pre-commit configurations. The most important changes include adding a new CI workflow for bot PRs, updating Python version support in CI tests, and updating type annotations to use the new union syntax.

### CI Workflow Improvements:
* Added a new CI workflow to automatically add the 'skip_changelog' label to PRs created by bots (`.github/workflows/ci_bot_pr_change.yml`).
* Updated Python version support in CI tests to include Python 3.13 (`.github/workflows/ci_tests.yml`).

### Type Annotation Updates:
* Updated type annotations to use the new union syntax (e.g., `str | None` instead of `Optional[str]`) across multiple files:
  * `oteapi_optimade/models/config.py` [[1]](diffhunk://#diff-7c492729926f00161ab85adc5b251105ee0d5a7f90c8289ad7d17e2a796837b9L25-R30) [[2]](diffhunk://#diff-7c492729926f00161ab85adc5b251105ee0d5a7f90c8289ad7d17e2a796837b9L39-R39) [[3]](diffhunk://#diff-7c492729926f00161ab85adc5b251105ee0d5a7f90c8289ad7d17e2a796837b9L60-R60) [[4]](diffhunk://#diff-7c492729926f00161ab85adc5b251105ee0d5a7f90c8289ad7d17e2a796837b9L111-R111) [[5]](diffhunk://#diff-7c492729926f00161ab85adc5b251105ee0d5a7f90c8289ad7d17e2a796837b9L120-R120)
  * `oteapi_optimade/models/custom_types.py` [[1]](diffhunk://#diff-23f80af265aa5dcce3114b2a368f67aae4cf32a9b20303438517c474a8c0fc44L94-R97) [[2]](diffhunk://#diff-23f80af265aa5dcce3114b2a368f67aae4cf32a9b20303438517c474a8c0fc44L118-R118) [[3]](diffhunk://#diff-23f80af265aa5dcce3114b2a368f67aae4cf32a9b20303438517c474a8c0fc44L148-R150) [[4]](diffhunk://#diff-23f80af265aa5dcce3114b2a368f67aae4cf32a9b20303438517c474a8c0fc44L179-R193) [[5]](diffhunk://#diff-23f80af265aa5dcce3114b2a368f67aae4cf32a9b20303438517c474a8c0fc44L268-R268)
  * `oteapi_optimade/models/query.py` [[1]](diffhunk://#diff-a48d82af120f8c6c39c96967a0f918412ba1ba630868040bc7085607fd62700dL30-R54) [[2]](diffhunk://#diff-a48d82af120f8c6c39c96967a0f918412ba1ba630868040bc7085607fd62700dL65-R65) [[3]](diffhunk://#diff-a48d82af120f8c6c39c96967a0f918412ba1ba630868040bc7085607fd62700dL74-R74) [[4]](diffhunk://#diff-a48d82af120f8c6c39c96967a0f918412ba1ba630868040bc7085607fd62700dL83-R83) [[5]](diffhunk://#diff-a48d82af120f8c6c39c96967a0f918412ba1ba630868040bc7085607fd62700dL92-R92) [[6]](diffhunk://#diff-a48d82af120f8c6c39c96967a0f918412ba1ba630868040bc7085607fd62700dL103-R103) [[7]](diffhunk://#diff-a48d82af120f8c6c39c96967a0f918412ba1ba630868040bc7085607fd62700dL112-R128) [[8]](diffhunk://#diff-a48d82af120f8c6c39c96967a0f918412ba1ba630868040bc7085607fd62700dL138-R138)
  * `oteapi_optimade/models/strategies/filter.py`

### Pre-commit Configuration Enhancements:
* Added `check-json` and `markdownlint-cli2` hooks to the pre-commit configuration (`.pre-commit-config.yaml`). [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R19-R20) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R34-R48)
* Updated `pyupgrade` hook arguments to target Python 3.10+ (`.pre-commit-config.yaml`).

### Miscellaneous:
* Removed an ignored safety advisory related to Jinja2 from CI tests (`.github/workflows/ci_tests.yml`).
* Added a default configuration for markdown linting (`.markdownlint.yaml`).