### PR TITLE
Drop `safety` in favor of `pip-audit`

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -19,10 +19,8 @@ jobs:
       run_pre-commit: false
 
       # pylint & safety
-      python_version_pylint_safety: "3.10"
       run_pylint: false
-
-      run_safety: true
+      run_safety: false
 
       # Build dist
       python_version_package: "3.10"
@@ -33,6 +31,27 @@ jobs:
       python_version_docs: "3.10"
       package_dirs: oteapi_optimade
       full_docs_dirs: "models"
+
+  pip-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout ${{ github.repository }}
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools wheel flit
+        pip install -e .[dev]
+
+    - name: Run pip-audit
+      uses: pypa/gh-action-pip-audit@v1.1.0
 
   pytest:
     name: pytest (${{ matrix.os[1] }}-py${{ matrix.python-version }})


### PR DESCRIPTION
Following the same thing done in other core OTE repositories.

## AI Summary

This pull request modifies the CI workflow configuration in `.github/workflows/ci_tests.yml` to adjust security checks and introduce a new job for dependency auditing. The most significant changes include disabling the `safety` check and adding a `pip-audit` job to the workflow.

### Changes to security checks:
* Disabled the `safety` check by setting `run_safety` to `false` under the `jobs` configuration. This change removes the use of the `safety` tool for dependency vulnerability scanning.

### Addition of `pip-audit` job:
* Introduced a new `pip-audit` job to perform dependency vulnerability checks using the `pip-audit` tool. The job includes steps to set up Python 3.10, install dependencies, and run the `pip-audit` GitHub Action.